### PR TITLE
Use openInTextLink() to open the post URL from the CommentPage

### DIFF
--- a/harmattan/qml/quickddit/CommentPage.qml
+++ b/harmattan/qml/quickddit/CommentPage.qml
@@ -270,7 +270,7 @@ AbstractPage {
 
                     Button {
                         iconSource: "image://theme/icon-l-browser-main-view"
-                        onClicked: globalUtils.createOpenLinkDialog(link.url);
+                        onClicked: globalUtils.openInTextLink(link.url);
                     }
                 }
 

--- a/sailfish/qml/CommentPage.qml
+++ b/sailfish/qml/CommentPage.qml
@@ -245,7 +245,7 @@ AbstractPage {
                         icon.height: Theme.iconSizeLarge - constant.paddingLarge
                         icon.width: Theme.iconSizeLarge - constant.paddingLarge
                         icon.source: "image://theme/icon-lock-social"
-                        onClicked: globalUtils.createOpenLinkDialog(link.url);
+                        onClicked: globalUtils.openInTextLink(link.url);
                     }
                 }
 


### PR DESCRIPTION
This makes Quickddit open an in-reddit URL (for example, the ones in /r/bestof) inside
the application.

Seems to work fine in my Jolla, even if I don't know if this is the right way to accomplish this. :)

I haven't tested the Harmattan change as I don't have an N9.


Eugenio