### PR TITLE
Formatting and flicking for preformatted text

### DIFF
--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -213,9 +213,8 @@ Item {
                 clip: true
 
                 MouseArea {
-                    width: commentBodyTextInner.paintedWidth
-                    height: commentBodyTextInner.height
-                    propagateComposedEvents: true
+                    anchors.fill: parent
+                    onClicked: commentDelegate.clicked()
                 }
 
                 Text {

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -201,16 +201,41 @@ Item {
                 }
             }
 
-            Text {
+            Flickable {
                 id: commentBodyText
-                anchors { left: parent.left; right: parent.right }
-                font.pixelSize: constant.fontSizeDefault
-                color: mainItem.enabled ? (mainItem.highlighted ? Theme.highlightColor : constant.colorLight)
-                                        : constant.colorDisabled
-                wrapMode: Text.Wrap
-                textFormat: Text.RichText
-                text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + model.body
-                onLinkActivated: globalUtils.openLink(link);
+                width: parent.width
+                height: commentBodyTextInner.height
+                anchors { left: parent.left; right: parent.right; }
+                contentWidth: model.body.indexOf("<pre>") < 0 ? commentBodyTextInner.width : commentBodyTextInnerHidden.width;
+                contentHeight: commentBodyTextInner.height
+                flickableDirection: Flickable.HorizontalFlick
+                interactive: model.body.indexOf("<pre>") >= 0;
+                clip: true
+
+                Text {
+                    id: commentBodyTextInner
+                    width: mainColumn.width
+                    font.pixelSize: constant.fontSizeDefault
+                    color: mainItem.enabled ? (mainItem.highlighted ? Theme.highlightColor : constant.colorLight)
+                                            : constant.colorDisabled
+                    wrapMode: Text.Wrap
+                    textFormat: Text.RichText
+                    text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + model.body
+                    onLinkActivated: globalUtils.openLink(link);
+                }
+
+                Text {
+                    id: commentBodyTextInnerHidden
+                    font.pixelSize: constant.fontSizeDefault
+                    color: "transparent"
+                    wrapMode: Text.Wrap
+                    textFormat: Text.RichText
+                    text: {
+                        var pre_only = model.body.replace(/<p>[^\n]+\n/g, '');
+                        "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + pre_only
+                    }
+                    onLinkActivated: globalUtils.openLink(link);
+                }
             }
         }
 

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -206,10 +206,10 @@ Item {
                 width: parent.width
                 height: commentBodyTextInner.height
                 anchors { left: parent.left; right: parent.right; }
-                contentWidth: model.body.indexOf("<pre>") < 0 ? commentBodyTextInner.width : commentBodyTextInnerHidden.width;
+                contentWidth: commentBodyTextInner.paintedWidth
                 contentHeight: commentBodyTextInner.height
                 flickableDirection: Flickable.HorizontalFlick
-                interactive: model.body.indexOf("<pre>") >= 0;
+                interactive: commentBodyTextInner.paintedWidth > parent.width
                 clip: true
 
                 Text {
@@ -220,20 +220,8 @@ Item {
                                             : constant.colorDisabled
                     wrapMode: Text.Wrap
                     textFormat: Text.RichText
-                    text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + model.body
-                    onLinkActivated: globalUtils.openLink(link);
-                }
-
-                Text {
-                    id: commentBodyTextInnerHidden
-                    font.pixelSize: constant.fontSizeDefault
-                    color: "transparent"
-                    wrapMode: Text.Wrap
-                    textFormat: Text.RichText
-                    text: {
-                        var pre_only = model.body.replace(/<p>[^\n]+\n?/g, '');
-                        "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + pre_only
-                    }
+                    text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) +
+                          "; } code { font-size: 20pt; } pre > code { font-size: 18pt; }</style>" + model.body
                     onLinkActivated: globalUtils.openLink(link);
                 }
             }

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -132,7 +132,7 @@ Item {
                 left: parent.left; right: parent.right; margins: constant.paddingMedium
                 verticalCenter: parent.verticalCenter
             }
-            height: authorTextWrapper.height + commentBodyText.paintedHeight
+            height: childrenRect.height
             spacing: constant.paddingSmall
 
             Item {
@@ -204,7 +204,7 @@ Item {
             Flickable {
                 id: commentBodyText
                 width: parent.width
-                height: commentBodyTextInner.height
+                height: childrenRect.height
                 anchors { left: parent.left; right: parent.right; }
                 contentWidth: commentBodyTextInner.paintedWidth
                 contentHeight: commentBodyTextInner.height

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -231,7 +231,7 @@ Item {
                     wrapMode: Text.Wrap
                     textFormat: Text.RichText
                     text: {
-                        var pre_only = model.body.replace(/<p>[^\n]+\n/g, '');
+                        var pre_only = model.body.replace(/<p>[^\n]+\n?/g, '');
                         "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + pre_only
                     }
                     onLinkActivated: globalUtils.openLink(link);

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -212,6 +212,12 @@ Item {
                 interactive: commentBodyTextInner.paintedWidth > parent.width
                 clip: true
 
+                MouseArea {
+                    width: commentBodyTextInner.paintedWidth
+                    height: commentBodyTextInner.height
+                    propagateComposedEvents: true
+                }
+
                 Text {
                     id: commentBodyTextInner
                     width: mainColumn.width

--- a/sailfish/qml/CommentDelegate.qml
+++ b/sailfish/qml/CommentDelegate.qml
@@ -220,8 +220,7 @@ Item {
                                             : constant.colorDisabled
                     wrapMode: Text.Wrap
                     textFormat: Text.RichText
-                    text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) +
-                          "; } code { font-size: 20pt; } pre > code { font-size: 18pt; }</style>" + model.body
+                    text: "<style>a { color: " + (mainItem.enabled ? Theme.highlightColor : constant.colorDisabled) + "; }</style>" + model.body
                     onLinkActivated: globalUtils.openLink(link);
                 }
             }

--- a/sailfish/qml/CommentPage.qml
+++ b/sailfish/qml/CommentPage.qml
@@ -270,7 +270,6 @@ AbstractPage {
 
                     Flickable {
                         id: bodyText
-                        width: parent.width
                         anchors { left: parent.left; right: parent.right; margins: constant.paddingMedium }
                         height: bodyTextInner.height
                         contentWidth: bodyTextInner.paintedWidth
@@ -281,7 +280,7 @@ AbstractPage {
 
                         Text {
                             id: bodyTextInner
-                            width: bodyWrapper.width
+                            width: bodyWrapper.width - (constant.paddingMedium * 2)
                             wrapMode: Text.Wrap
                             textFormat: Text.RichText
                             font.pixelSize: constant.fontSizeDefault

--- a/sailfish/qml/CommentPage.qml
+++ b/sailfish/qml/CommentPage.qml
@@ -274,7 +274,7 @@ AbstractPage {
                         height: bodyTextInner.height
                         contentWidth: bodyTextInner.paintedWidth
                         contentHeight: bodyTextInner.height
-                        flickDeceleration: Flickable.HorizontalFlick
+                        flickableDirection: Flickable.HorizontalFlick
                         interactive: bodyTextInner.paintedWidth > parent.width
                         clip: true
 

--- a/sailfish/qml/CommentPage.qml
+++ b/sailfish/qml/CommentPage.qml
@@ -285,8 +285,7 @@ AbstractPage {
                             textFormat: Text.RichText
                             font.pixelSize: constant.fontSizeDefault
                             color: constant.colorLight
-                            text: "<style>a { color: " + Theme.highlightColor +
-                                  "; } code { font-size: 20pt; } pre > code { font-size: 18pt; }</style>" + link.text
+                            text: "<style>a { color: " + Theme.highlightColor + "; }</style>" + link.text
                             onLinkActivated: globalUtils.openLink(link);
                         }
                     }

--- a/sailfish/qml/CommentPage.qml
+++ b/sailfish/qml/CommentPage.qml
@@ -268,15 +268,28 @@ AbstractPage {
                         color: constant.colorMid
                     }
 
-                    Text {
+                    Flickable {
                         id: bodyText
+                        width: parent.width
                         anchors { left: parent.left; right: parent.right; margins: constant.paddingMedium }
-                        wrapMode: Text.Wrap
-                        textFormat: Text.RichText
-                        font.pixelSize: constant.fontSizeDefault
-                        color: constant.colorLight
-                        text: "<style>a { color: " + Theme.highlightColor + "; }</style>" + link.text
-                        onLinkActivated: globalUtils.openLink(link);
+                        height: bodyTextInner.height
+                        contentWidth: bodyTextInner.paintedWidth
+                        contentHeight: bodyTextInner.height
+                        flickDeceleration: Flickable.HorizontalFlick
+                        interactive: bodyTextInner.paintedWidth > parent.width
+                        clip: true
+
+                        Text {
+                            id: bodyTextInner
+                            width: bodyWrapper.width
+                            wrapMode: Text.Wrap
+                            textFormat: Text.RichText
+                            font.pixelSize: constant.fontSizeDefault
+                            color: constant.colorLight
+                            text: "<style>a { color: " + Theme.highlightColor +
+                                  "; } code { font-size: 20pt; } pre > code { font-size: 18pt; }</style>" + link.text
+                            onLinkActivated: globalUtils.openLink(link);
+                        }
                     }
 
                     // For spacing after text

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -42,24 +42,9 @@ QString unescapeHtml(const QString &html)
     // as the deep-copy and replace might be expensive, only take the effort when
     // a <pre> tag is present
     if (html.contains("&lt;pre&gt;")) {
-        QString shieldedHtml;
-        shieldedHtml.reserve(html.length());
-
-        // preserve spaces for content of <pre>
-        QLatin1String open("&lt;pre&gt;");
-        QLatin1String close("&lt;/pre&gt;");
-        for (int i = 0, pos = 0, next = html.indexOf(open, pos); next >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
-            if (i % 2 == 0) {
-                shieldedHtml.append(QStringRef(&html, pos, next - pos));
-            } else {
-                // in <pre>
-                QString pre_content(QStringRef(&html, pos, next - pos).toString());
-                pre_content.replace(" ", "&nbsp;");
-                shieldedHtml.append(pre_content);
-            }
-        }
-
+        QString shieldedHtml(html);
         shieldedHtml.replace("\n", "&lt;&gt;");
+        shieldedHtml.replace(" ", "&nbsp;");
         document.setHtml(shieldedHtml);
         unescaped = document.toPlainText();
         unescaped.replace("<>", "\n");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -42,9 +42,24 @@ QString unescapeHtml(const QString &html)
     // as the deep-copy and replace might be expensive, only take the effort when
     // a <pre> tag is present
     if (html.contains("&lt;pre&gt;")) {
-        QString shieldedHtml(html);
+        QString shieldedHtml;
+        shieldedHtml.reserve(html.length());
+
+        // preserve spaces for content of <pre>
+        QLatin1String open("&lt;pre&gt;");
+        QLatin1String close("&lt;/pre&gt;");
+        for (int i = 0, pos = 0, next = html.indexOf(open, pos); next >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
+            if (i % 2 == 0) {
+                shieldedHtml.append(QStringRef(&html, pos, next - pos));
+            } else {
+                // in <pre>
+                QString pre_content(QStringRef(&html, pos, next - pos).toString());
+                pre_content.replace(" ", "&nbsp;");
+                shieldedHtml.append(pre_content);
+            }
+        }
+
         shieldedHtml.replace("\n", "&lt;&gt;");
-        shieldedHtml.replace(" ", "&nbsp;");
         document.setHtml(shieldedHtml);
         unescaped = document.toPlainText();
         unescaped.replace("<>", "\n");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -48,10 +48,8 @@ QString unescapeHtml(const QString &html)
         // preserve spaces for content of <pre>
         QLatin1String open("&lt;pre&gt;");
         QLatin1String close("&lt;/pre&gt;");
-        for (int i = 0, pos = 0, next = html.indexOf(open, pos); pos >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
-            if (next < 0) {
-                shieldedHtml.append(QStringRef(&html, pos, html.length() - pos - 1));
-            } else if (i % 2 == 0) {
+        for (int i = 0, pos = 0, next = html.indexOf(open, pos); next >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
+            if (i % 2 == 0) {
                 shieldedHtml.append(QStringRef(&html, pos, next - pos));
             } else {
                 // in <pre>

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -48,8 +48,10 @@ QString unescapeHtml(const QString &html)
         // preserve spaces for content of <pre>
         QLatin1String open("&lt;pre&gt;");
         QLatin1String close("&lt;/pre&gt;");
-        for (int i = 0, pos = 0, next = html.indexOf(open, pos); next >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
-            if (i % 2 == 0) {
+        for (int i = 0, pos = 0, next = html.indexOf(open, pos); pos >= 0; pos = next, next = html.indexOf(i % 2 == 0 ? close : open, pos), i++) {
+            if (next < 0) {
+                shieldedHtml.append(QStringRef(&html, pos, html.length() - pos - 1));
+            } else if (i % 2 == 0) {
                 shieldedHtml.append(QStringRef(&html, pos, next - pos));
             } else {
                 // in <pre>

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -44,6 +44,7 @@ QString unescapeHtml(const QString &html)
     if (html.contains("&lt;pre&gt;")) {
         QString shieldedHtml(html);
         shieldedHtml.replace("\n", "&lt;&gt;");
+        shieldedHtml.replace(" ", "&nbsp;");
         document.setHtml(shieldedHtml);
         unescaped = document.toPlainText();
         unescaped.replace("<>", "\n");


### PR DESCRIPTION
This is quite ugly but realy cheap solution.

Only comments with preformatted text become flickable.
Downside is that now user will have to click on a header of a flickable comment to select it, because in other case click event will be stolen.

`commentBodyTextInnerHidden` required to properly set `Flickable.contentWidth`. I couldn't see another way to do it cheaply.
