### PR TITLE
Fix build and segfault in harmattan

### DIFF
--- a/harmattan/main.cpp
+++ b/harmattan/main.cpp
@@ -38,7 +38,6 @@
 #include "src/imgurmanager.h"
 #include "src/votemanager.h"
 #include "src/commentmanager.h"
-#include "src/captchamanager.h"
 #include "src/linkmanager.h"
 #include "src/inboxmanager.h"
 #include "src/usermanager.h"
@@ -66,7 +65,6 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     qmlRegisterType<ImgurManager>("Quickddit.Core", 1, 0, "ImgurManager");
     qmlRegisterType<VoteManager>("Quickddit.Core", 1, 0, "VoteManager");
     qmlRegisterType<CommentManager>("Quickddit.Core", 1, 0, "CommentManager");
-    qmlRegisterType<CaptchaManager>("Quickddit.Core", 1, 0, "CaptchaManager");
     qmlRegisterType<LinkManager>("Quickddit.Core", 1, 0, "LinkManager");
     qmlRegisterType<InboxManager>("Quickddit.Core", 1, 0, "InboxManager");
     qmlRegisterType<UserManager>("Quickddit.Core", 1, 0, "UserManager");

--- a/harmattan/qml/quickddit/main.qml
+++ b/harmattan/qml/quickddit/main.qml
@@ -199,11 +199,6 @@ PageStackWindow {
         }
     }
 
-    CaptchaManager {
-        id: captchaManager
-        manager: quickdditManager
-    }
-
     InboxManager {
         id: inboxManager
         manager: quickdditManager

--- a/harmattan/quickddit.pro
+++ b/harmattan/quickddit.pro
@@ -36,7 +36,6 @@ HEADERS += \
     ../src/messagemanager.h \
     ../src/apirequest.h \
     ../src/aboutmultiredditmanager.h \
-    ../src/captchamanager.h \
     ../src/linkmanager.h \
     ../src/inboxmanager.h \
     ../src/usermanager.h \
@@ -73,7 +72,6 @@ SOURCES += main.cpp \
     ../src/messagemanager.cpp \
     ../src/apirequest.cpp \
     ../src/aboutmultiredditmanager.cpp \
-    ../src/captchamanager.cpp \
     ../src/linkmanager.cpp \
     ../src/inboxmanager.cpp \
     ../src/usermanager.cpp \

--- a/src/aboutsubredditmanager.cpp
+++ b/src/aboutsubredditmanager.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see [http://www.gnu.org/licenses/].
 */
 
+#include <QDebug>
 #include <QtNetwork/QNetworkReply>
 
 #include "aboutsubredditmanager.h"

--- a/src/commentmodel.cpp
+++ b/src/commentmodel.cpp
@@ -545,6 +545,8 @@ void CommentModel::moreComments(int index, const QVariant &children)
     QStringList const limitedChildrenList = childrenList.mid(0,50);
     if (childrenList.size() > 50) {
         m_moremoreComments = childrenList.mid(50);
+    } else {
+        m_moremoreComments.clear();
     }
     parameters["children"] = limitedChildrenList.join(",");
 

--- a/src/commentmodel.cpp
+++ b/src/commentmodel.cpp
@@ -541,8 +541,11 @@ void CommentModel::moreComments(int index, const QVariant &children)
     QHash<QString, QString> parameters;
     parameters["sort"] = getSortString(m_sort);
     parameters["link_id"] = linkMap.value("fullname").toString();
-    QStringList limitedChildrenList(children.toStringList().mid(0,50));
-    m_moremoreComments = children.toStringList().mid(50);
+    QStringList const childrenList = children.toStringList();
+    QStringList const limitedChildrenList = childrenList.mid(0,50);
+    if (childrenList.size() > 50) {
+        m_moremoreComments = childrenList.mid(50);
+    }
     parameters["children"] = limitedChildrenList.join(",");
 
     doRequest(APIRequest::GET, "/api/morechildren", SLOT(onMoreCommentsFinished(QNetworkReply*)), parameters);

--- a/src/linkmanager.cpp
+++ b/src/linkmanager.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see [http://www.gnu.org/licenses/].
 */
 
+#include <QDebug>
 #include <QtNetwork/QNetworkReply>
 
 #include "linkmanager.h"


### PR DESCRIPTION
Hi,
I had to make some changes to be able to build with the harmattan SDK in QtCreator.
The actual reason for my involvement is the segfault in harmattan when clicking "Load X more comments" in the thread/comments view.
Regards,
--Marco