### PR TITLE
Generates a menu option for deleted comments

### DIFF
--- a/sailfish/qml/CommentMenu.qml
+++ b/sailfish/qml/CommentMenu.qml
@@ -110,6 +110,15 @@ FancyContextMenu {
             pageStack.push(Qt.resolvedUrl("UserPage.qml"), { username: comment.author.split(" ")[0] } );
         }
     }
+    
+     MenuItem {
+        visible: !comment.isValid && comment.rawBody === "[removed]"
+        text: "Uncensor"
+        onClicked: {
+                var link = "https://www.removeddit.com" + post.permalink + comment.fullname.substring(3);
+                globalUtils.createOpenLinkDialog(link);
+            }
+        }
 
     Component.onDestruction: {
         if (__showParentAtDestruction)

--- a/sailfish/qml/CommentMenu.qml
+++ b/sailfish/qml/CommentMenu.qml
@@ -112,7 +112,7 @@ FancyContextMenu {
     }
     
      MenuItem {
-        visible: !comment.isValid && comment.rawBody === "[removed]"
+        visible: !comment.isValid && (comment.rawBody === "[removed]" || comment.rawBody === "[deleted]")
         text: "Uncensor"
         onClicked: {
                 var link = "https://www.removeddit.com" + post.permalink + comment.fullname.substring(3);


### PR DESCRIPTION
Allows opening deleted comments in removeddit (seems to render best in webview and is faster than ceddit), partial fix for #58 maybe? Ideally the deleted comments could be populated in to the listview, but not sure how realistic that is (and if any of the uncensoring tools have a good api for that to be possible)