### PR TITLE
Fix for "tall" screenshots of twitter/fb convos being hazy

### DIFF
--- a/sailfish/qml/ImageViewer.qml
+++ b/sailfish/qml/ImageViewer.qml
@@ -138,8 +138,8 @@ Item {
 
             // workaround CustomContext::HybrisTexture::bind:313 - Error after glEGLImageTargetTexture2DOES 501
             // animatedimage cannot restrict the source size, which can lead to the above error
-            sourceSize.width: 2048
-            sourceSize.height: 2048
+            sourceSize.width: 4096
+            sourceSize.height: 4096
 
             anchors.centerIn: parent
             asynchronous: true


### PR DESCRIPTION
Like this example https://i.redd.it/rofslowas4941.jpg probably won't fix it for all extreme cases but in the given example makes the thread readable