### PR TITLE
Ubuntu Touch: Change hard-coded sizes into Suru units

### DIFF
--- a/ubuntu-touch/Qml/ActionButton.qml
+++ b/ubuntu-touch/Qml/ActionButton.qml
@@ -24,12 +24,12 @@ import QtQuick.Controls.Suru 2.2
 ToolButton {
     id: actionButton
     height: parent.height
-    width: 36
+    width: Suru.units.gu(4.5)
     hoverEnabled: false
     //after QT update we can use icon property
     property url ico
     property color color
-    property int size: 24
+    property int size: Suru.units.gu(3)
     Image {
         anchors.centerIn: parent
         source: ico

--- a/ubuntu-touch/Qml/Delegates/LinkDelegate.qml
+++ b/ubuntu-touch/Qml/Delegates/LinkDelegate.qml
@@ -53,7 +53,7 @@ ItemDelegate {
         id: info
         color: Suru.foregroundColor
         linkColor: Suru.color(Suru.Orange,1)
-        padding: 5
+        padding: Suru.units.gu(1)
         anchors {top: parent.top; left: parent.left; right: parent.right; }
         elide: Text.ElideRight
         text: "<a href='/r/"+link.subreddit+"'>"+"/r/"+link.subreddit+"</a>"+" ~ <a href='/u/"+link.author+"'>"+"/u/"+link.author+"</a>"+" ~ "+link.created+" ~ "+link.domain+((!compact && link.crossposts > 0) ? ". <a href=\"cross:" + link.fullname + "\">" + qsTr("%n crossposts", "", link.crossposts) + "</a>" : "")
@@ -75,7 +75,7 @@ ItemDelegate {
         width: contentWidth
         orientation: ListView.Horizontal
         clip: true
-        spacing: 5
+        spacing: Suru.units.gu(1)
         delegate: Loader {
             active: modelData != ""
             sourceComponent: Flair { text: modelData }
@@ -96,21 +96,21 @@ ItemDelegate {
 
     //title
     Label {
-        padding: 5
+        padding: Suru.units.gu(1)
         anchors {top: flairs.bottom; right: parent.right; left:thumb.visible ? thumb.right : parent.left }
         id: titulok
         text: link.title
         elide: Text.ElideRight
         maximumLineCount: compact && !thumb.visible ? 3 : 9999
         height: thumb.visible && compact ? thumb.height - flairs.height : implicitHeight
-        font.pointSize: 12
+        font.pixelSize: Suru.units.rem(1)
         font.weight: Font.DemiBold
         wrapMode: Text.Wrap
     }
     //text
     Label {
         id:txt
-        padding: 5
+        padding: Suru.units.gu(1)
 
         color: Suru.foregroundColor
         linkColor: Suru.color(Suru.Orange,1)
@@ -125,6 +125,7 @@ ItemDelegate {
         wrapMode: Text.WordWrap
         textFormat: compact ? Text.StyledText : Text.RichText
         onLinkActivated: globalUtils.openLink(link)
+        font: Suru.units.fontParagraph
     }
     //preview
     Thumbnail {

--- a/ubuntu-touch/Qml/MenuItem.qml
+++ b/ubuntu-touch/Qml/MenuItem.qml
@@ -1,18 +1,19 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 
 MenuItem {
     property string ico
     property string txt
     Row {
         height: parent.height
-        spacing: 10
-        leftPadding: 10
+        spacing: Suru.units.gu(2)
+        leftPadding: Suru.units.gu(1)
         Image {
             anchors.verticalCenter: parent.verticalCenter
             source: ico
-            width: 18
-            height: 18
+            width: Suru.units.gu(3)
+            height: Suru.units.gu(3)
         }
         Label {
             anchors.verticalCenter: parent.verticalCenter

--- a/ubuntu-touch/Qml/Pages/AboutPage.qml
+++ b/ubuntu-touch/Qml/Pages/AboutPage.qml
@@ -20,6 +20,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
 import QtGraphicalEffects 1.0
+import QtQuick.Controls.Suru 2.2
 
 Page {
     title: qsTr("About")
@@ -27,7 +28,7 @@ Page {
         anchors.fill: parent
         header:Column {
             id:aboutColumn
-            topPadding: 10
+            topPadding: Suru.units.gu(2)
             width: parent.width
 
             Image {
@@ -35,10 +36,10 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
                 source: "qrc:/Icons/quickddit.svg"
                 layer.enabled: true
-                width: 120
-                height: 120
-                sourceSize.height:120
-                sourceSize.width:120
+                width: Suru.units.gu(15)
+                height: Suru.units.gu(15)
+                sourceSize.height: Suru.units.gu(15)
+                sourceSize.width: Suru.units.gu(15)
 
                 layer.effect:
                     OpacityMask {
@@ -59,9 +60,9 @@ Page {
 
             Label {
                 text: "Quickddit"
-                padding: 10
+                padding: Suru.units.gu(2)
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 18
+                font.pixelSize: Suru.units.rem(1.5)
             }
 
             Label {

--- a/ubuntu-touch/Qml/Pages/AccountsPage.qml
+++ b/ubuntu-touch/Qml/Pages/AccountsPage.qml
@@ -38,13 +38,13 @@ Page {
 
             ToolButton {
                 anchors.right: parent.right
-                anchors.rightMargin: 12
+                anchors.rightMargin: Suru.units.gu(2)
                 height: parent.height
                 hoverEnabled: false
 
                 Image {
-                    height: 24
-                    width: 24
+                    height: Suru.units.gu(3)
+                    width: Suru.units.gu(3)
                     anchors.centerIn: parent
                     source: "qrc:/Icons/delete.svg"
                 }

--- a/ubuntu-touch/Qml/Pages/CommentPage.qml
+++ b/ubuntu-touch/Qml/Pages/CommentPage.qml
@@ -60,7 +60,7 @@ Page {
             ActionButton {
                 id:downloadBtn
                 ico: "qrc:/Icons/save.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 visible: previeableImage
                 onClicked: downloadImage()
@@ -69,7 +69,7 @@ Page {
             ActionButton {
                 id:sort
                 ico: "qrc:/Icons/filters.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 onClicked: sortMenu.open()
                 Menu {
@@ -104,7 +104,7 @@ Page {
             ActionButton {
                 id:del
                 ico: "qrc:/Icons/delete.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 visible: link.author === appSettings.redditUsername
                 enabled: !link.isArchived
@@ -117,7 +117,7 @@ Page {
             ActionButton {
                 id:edit
                 ico: "qrc:/Icons/edit.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 visible: link.author === appSettings.redditUsername
                 enabled: !link.isArchived
@@ -136,7 +136,7 @@ Page {
             ActionButton {
                 id:newPost
                 ico: "qrc:/Icons/add.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 visible: quickdditManager.isSignedIn
                 enabled: !commentManager.busy && !link.isArchived && !link.isLocked

--- a/ubuntu-touch/Qml/Pages/DonatePage.qml
+++ b/ubuntu-touch/Qml/Pages/DonatePage.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 
 Page {
     title: "Donate"
@@ -31,52 +32,52 @@ Page {
         Column {
             id:mainColumn
             width: parent.parent.width
-            padding: 10
-            spacing: 8
+            padding: Suru.units.gu(2)
+            spacing: Suru.units.gu(1)
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 16
+                font.pixelSize: Suru.units.rem(1.5)
                 text: "Sander van Grieken "
             }
 
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: qsTr("(maintainer)")
             }
 
             Image {
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: 48
+                width: Suru.units.gu(6)
                 height: width
                 source: "qrc:/Img/paypal.png"
             }
 
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: "Donate via PayPal:"
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: "<a href=\"" + _paypalLink + "\">" + _paypalLink + "</a>"
                 onLinkActivated: Qt.openUrlExternally(_paypalLink);
             }
             Image {
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: 48
+                width: Suru.units.gu(6)
                 height: width
                 source: "qrc:/Img/bitcoin.png"
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: qsTr("Donate via Bitcoin:")
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: "<a href=\"" + _bitcoinAddr + "\">" + _bitcoinAddr + "</a>"
                 onLinkActivated: {
                     QMLUtils.copyToClipboard(_bitcoinAddr)
@@ -85,30 +86,30 @@ Page {
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 16
+                font.pixelSize: Suru.units.rem(1.5)
                 text: "Daniel Kutka"
             }
 
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: qsTr("(ubuntu-touch port)")
             }
 
             Image {
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: 48
+                width: Suru.units.gu(6)
                 height: width
                 source: "qrc:/Img/paypal.png"
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: qsTr("Donate via PayPal:")
             }
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pointSize: 12
+                font.pixelSize: Suru.units.rem(1)
                 text: "<a href=\"" + _paypalLink_dk + "\">" + _paypalLink_dk + "</a>"
                 onLinkActivated: Qt.openUrlExternally(_paypalLink_dk);
             }

--- a/ubuntu-touch/Qml/Pages/ImageViewPage.qml
+++ b/ubuntu-touch/Qml/Pages/ImageViewPage.qml
@@ -38,7 +38,7 @@ Page {
             ActionButton {
                 id:downloadBtn
                 ico: "qrc:/Icons/save.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 visible: true
                 onClicked: QMLUtils.saveImage(imageUrl)

--- a/ubuntu-touch/Qml/Pages/LoginPage.qml
+++ b/ubuntu-touch/Qml/Pages/LoginPage.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.9
 import QtWebEngine 1.7
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import quickddit.Core 1.0
 import Qt.labs.platform 1.0
 
@@ -28,6 +29,7 @@ Page {
         id:loginPage
         settings.localContentCanAccessFileUrls: true
         settings.localContentCanAccessRemoteUrls: true
+        zoomFactor: Suru.units.dp(1.0)
         profile: WebEngineProfile{
             persistentStoragePath: StandardPaths.writableLocation(StandardPaths.DataLocation).toString().substring(7)
         }

--- a/ubuntu-touch/Qml/Pages/MainPage.qml
+++ b/ubuntu-touch/Qml/Pages/MainPage.qml
@@ -165,7 +165,7 @@ Page {
         TabBar{
         id: tabBar
         contentHeight: undefined
-        leftPadding: 10
+        leftPadding: Suru.units.gu(2)
         background: Rectangle {
             color: Suru.color(Suru.Orange,1)
         }
@@ -179,7 +179,7 @@ Page {
                 color: tb0.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
 
         }
         TabButton {
@@ -191,7 +191,7 @@ Page {
                 color: parent.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
         }
         TabButton {
             id:tb2
@@ -202,7 +202,7 @@ Page {
                 color: parent.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
         }
         TabButton {
             id:tb3
@@ -213,7 +213,7 @@ Page {
                 color: parent.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
         }
         TabButton {
             id:tb4
@@ -224,7 +224,7 @@ Page {
                 color: parent.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
         }
         TabButton {
             id:tb5
@@ -235,7 +235,7 @@ Page {
                 color: parent.checked ? Suru.color(Suru.White,1) : Suru.color(Suru.Porcelain,1)
             }
             width: implicitWidth
-            padding:6
+            padding: Suru.units.gu(1)
         }
 
 
@@ -260,7 +260,7 @@ Page {
             highlightFollowsCurrentItem: false
 
             Label {
-                anchors { bottom: linkListView.contentItem.top; horizontalCenter: parent.horizontalCenter; margins: 75 }
+                anchors { bottom: linkListView.contentItem.top; horizontalCenter: parent.horizontalCenter; margins: Suru.units.gu(10) }
                 text: qsTr("Pull to refresh...")
             }
 
@@ -278,7 +278,7 @@ Page {
             }
 
             onContentYChanged: {
-                if(contentY<=-150 && !linkModel.busy)
+                if(contentY<=-Suru.units.gu(18) && !linkModel.busy)
                     linkModel.refresh(false)
             }
 

--- a/ubuntu-touch/Qml/Pages/MainPage.qml
+++ b/ubuntu-touch/Qml/Pages/MainPage.qml
@@ -141,20 +141,20 @@ Page {
             ActionButton {
                 id:info
                 ico: "qrc:/Icons/info.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 enabled: linkModel.location == LinkModel.Subreddit
                 color: Suru.color(Suru.White,1)
-                width: enabled ? 40 : 0
+                width: enabled ? Suru.units.gu(4.5) : 0
                 clip: true
                 onClicked: {pageStack.push(Qt.resolvedUrl("qrc:/Qml/Pages/SubredditPage.qml"),{subreddit:linkModel.subreddit})}
             }
             ActionButton {
                 id:newPost
                 ico: "qrc:/Icons/add.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 enabled: quickdditManager.isSignedIn
                 color: Suru.color(Suru.White,1)
-                width: linkModel.location == LinkModel.Subreddit ? 40 : 0
+                width: linkModel.location == LinkModel.Subreddit ? Suru.units.gu(4.5) : 0
                 clip: true
                 onClicked: {pageStack.push(Qt.resolvedUrl("qrc:/Qml/Pages/SendLinkPage.qml"), {linkManager: linkManager, subreddit: linkModel.subreddit})}
             }

--- a/ubuntu-touch/Qml/Pages/MessagePage.qml
+++ b/ubuntu-touch/Qml/Pages/MessagePage.qml
@@ -36,7 +36,7 @@ Page {
             ActionButton {
                 id:newPost
                 ico: "qrc:/Icons/message-new.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 onClicked: {
                     pageStack.push(Qt.resolvedUrl("qrc:/Qml/Pages/SendMessagePage.qml"), {messageManager: messageManager});

--- a/ubuntu-touch/Qml/Pages/MultiredditPage.qml
+++ b/ubuntu-touch/Qml/Pages/MultiredditPage.qml
@@ -39,7 +39,7 @@ Page {
         CircleImage {
             id:logo
             source: multiredditManager.iconUrl
-            anchors{left: parent.left;top:parent.top; leftMargin: 20}
+            anchors{left: parent.left;top:parent.top; leftMargin: Suru.units.gu(3)}
             width: Math.min(150,parent.width/4)
             height: width
             Component.onCompleted: console.log(source)
@@ -49,18 +49,18 @@ Page {
             id:fullName
             text: multireddit
             font.pointSize: 18
-            anchors{ left: logo.right;bottom: name.top;leftMargin: 20}
+            anchors{ left: logo.right;bottom: name.top;leftMargin: Suru.units.gu(3)}
         }
 
         Label {
             id:name
             text: "m/"+multireddit
-            anchors{left: logo.right;bottom: logo.bottom;leftMargin: 20}
+            anchors{left: logo.right;bottom: logo.bottom;leftMargin: Suru.units.gu(3)}
         }
 
         Label {
             id:about
-            anchors {left: parent.left;right: parent.right;top: name.bottom; margins:10}
+            anchors {left: parent.left;right: parent.right;top: name.bottom; margins:Suru.units.gu(2)}
             text: multiredditManager.description
             wrapMode: "WordWrap"
         }
@@ -68,7 +68,7 @@ Page {
         Button {
             id:showButton
             text: qsTr("Show posts in m/")+multireddit
-            anchors { horizontalCenter: parent.horizontalCenter; top: about.bottom; margins: 10}
+            anchors { horizontalCenter: parent.horizontalCenter; top: about.bottom; margins: Suru.units.gu(2)}
             onClicked: {
                 globalUtils.getMainPage().refreshMR(multireddit)
                 pageStack.pop(globalUtils.getMainPage(),StackView.ReplaceTransition)

--- a/ubuntu-touch/Qml/Pages/SendLinkPage.qml
+++ b/ubuntu-touch/Qml/Pages/SendLinkPage.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import quickddit.Core 1.0
 import "../"
 
@@ -57,14 +58,14 @@ Page {
 
     Flickable {
         id: scrollView
-        anchors { fill: parent; margins: 10 }
+        anchors { fill: parent; margins: Suru.units.gu(2) }
         contentHeight: mainContentColumn.height
         contentWidth: width
 
         Column {
             id: mainContentColumn
             width: parent.width
-            spacing: 10
+            spacing: Suru.units.gu(2)
 
             Label {
                 anchors {right: parent.right; }
@@ -116,7 +117,7 @@ Page {
             }
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
-                spacing: 10
+                spacing: Suru.units.gu(2)
                 Button {
                     text: editPost === "" ? qsTr("Submit") : qsTr("Save")
                     enabled: (editPost != "" || linkTitle.text.length > 0) /* official limits? */

--- a/ubuntu-touch/Qml/Pages/SendMessagePage.qml
+++ b/ubuntu-touch/Qml/Pages/SendMessagePage.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import "../"
 
 Page {
@@ -40,13 +41,13 @@ Page {
 
     Flickable {
         id: flickable
-        anchors { fill: parent; margins: 10 }
+        anchors { fill: parent; margins: Suru.units.gu(2) }
         contentHeight: mainContentColumn.height
 
         Column {
             id: mainContentColumn
             width: parent.width
-            spacing: 5
+            spacing: Suru.units.gu(1)
 
             TextField {
                 id: recipientField
@@ -59,7 +60,7 @@ Page {
             Label {
                 anchors {right: parent.right; rightMargin: 5 }
                 text: (recipient.indexOf("/r") == 0 ? qsTr("to moderators of") : qsTr("to")) + " " + recipient
-                font.pointSize: 10
+                font.pixelSize: Suru.units.rem(0.8)
                 visible : recipient !== ""
             }
 
@@ -79,7 +80,7 @@ Page {
 
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
-                spacing: 10
+                spacing: Suru.units.gu(2)
 
                 Button {
                     text: qsTr("Send")

--- a/ubuntu-touch/Qml/Pages/SettingsPage.qml
+++ b/ubuntu-touch/Qml/Pages/SettingsPage.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import quickddit.Core 1.0
 
 Page {
@@ -55,12 +56,12 @@ Page {
                 width: parent.width
                 Label {
                     id:sliderLabel
-                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: 10}
+                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: Suru.units.gu(2)}
                     text: qsTr("Thumbnail scale:")+" ["+Math.floor(slider.value*100)+"%]"
                 }
                 Slider {
                     id:slider
-                    anchors { right: parent.right; left:sliderLabel.right;  verticalCenter: parent.verticalCenter; margins:10 }
+                    anchors { right: parent.right; left:sliderLabel.right;  verticalCenter: parent.verticalCenter; margins:Suru.units.gu(2) }
                     from: 0.5
                     to: 1.5
                     stepSize: 0.1
@@ -74,11 +75,11 @@ Page {
             ItemDelegate {
                 width: parent.width
                 Label {
-                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: 10}
+                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: Suru.units.gu(2)}
                     text: "Preferred Video Size"
                 }
                 ComboBox {
-                    anchors { right: parent.right;  verticalCenter: parent.verticalCenter; margins:10 }
+                    anchors { right: parent.right;  verticalCenter: parent.verticalCenter; margins: Suru.units.gu(2) }
                     model: ["360p","720p"]
                     currentIndex: appSettings.preferredVideoSize
                     onCurrentIndexChanged: {
@@ -104,11 +105,11 @@ Page {
             ItemDelegate {
                 width: parent.width
                 Label {
-                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: 10}
+                    anchors {left: parent.left;verticalCenter: parent.verticalCenter; margins: Suru.units.gu(2)}
                     text: qsTr("Theme")
                 }
                 ComboBox {
-                    anchors { right: parent.right;  verticalCenter: parent.verticalCenter; margins:10 }
+                    anchors { right: parent.right;  verticalCenter: parent.verticalCenter; margins: Suru.units.gu(2) }
                     model: ["Light","Dark","System"]
                     currentIndex: persistantSettings.theme
                     onCurrentIndexChanged: {
@@ -124,9 +125,9 @@ Page {
                 Image {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
-                    anchors.rightMargin: 12
-                    width: 24
-                    height: 24
+                    anchors.rightMargin: Suru.units.gu(2)
+                    width: Suru.units.gu(3)
+                    height: Suru.units.gu(3)
                     source: "qrc:/Icons/next.svg"
                 }
             }

--- a/ubuntu-touch/Qml/Pages/SubredditPage.qml
+++ b/ubuntu-touch/Qml/Pages/SubredditPage.qml
@@ -33,7 +33,7 @@ Page {
     ScrollView{
         anchors.fill: parent
         contentWidth: parent.width
-        contentHeight: logo.height + Math.max(headerImage.height,30) + subButton.height + showButton.height + about.height + wiki.height
+        contentHeight: logo.height + Math.max(headerImage.height,Suru.units.gu(4)) + subButton.height + showButton.height + about.height + wiki.height
         ScrollBar.vertical.interactive: false
 
         Image {
@@ -46,26 +46,26 @@ Page {
         CircleImage {
             id:logo
             source: aboutSubredditManager.iconUrl
-            anchors{left: parent.left;top:headerImage.bottom; leftMargin: 20; topMargin: -Math.min(50,headerImage.height)}
-            width: Math.min(150,parent.width/4)
+            anchors{left: parent.left;top:headerImage.bottom; leftMargin: Suru.units.gu(3); topMargin: -Math.min(Suru.units.gu(6),headerImage.height)}
+            width: Math.min(Suru.units.gu(18),parent.width/4)
             height: width
         }
 
         Label {
             id:fullName
             text: "/r/"+subreddit
-            font.pointSize: 18
-            anchors{ left: logo.right;bottom: name.top;leftMargin: 20}
+            font.pixelSize: Suru.units.rem(1)
+            anchors{ left: logo.right;bottom: name.top;leftMargin: Suru.units.gu(3)}
         }
 
         Label {
             id:name
             text: aboutSubredditManager.title
-            anchors{left: logo.right;bottom: logo.bottom;leftMargin: 20}
+            anchors{left: logo.right;bottom: logo.bottom;leftMargin: Suru.units.gu(3)}
         }
 
         Button {
-            anchors{top: logo.bottom;right: parent.right;margins: 5}
+            anchors{top: logo.bottom;right: parent.right;margins: Suru.units.gu(1)}
             id:subButton
             text: aboutSubredditManager.isSubscribed?qsTr("Unsubscribe"):qsTr("Subscribe")
             onClicked: {
@@ -78,13 +78,13 @@ Page {
 
         Label {
             id:subCount
-            anchors{right: subButton.left;verticalCenter:  subButton.verticalCenter; margins: 5}
+            anchors{right: subButton.left;verticalCenter:  subButton.verticalCenter; margins: Suru.units.gu(1)}
             text: aboutSubredditManager.activeUsers + " "+qsTr("active")+" / " + aboutSubredditManager.subscribers + " "+qsTr("subs")
         }
 
         Label {
             id:about
-            anchors {left: parent.left;right: parent.right;top: subButton.bottom; margins:10}
+            anchors {left: parent.left;right: parent.right;top: subButton.bottom; margins:Suru.units.gu(2) }
             text: aboutSubredditManager.shortDescription
             wrapMode: "WordWrap"
         }
@@ -92,7 +92,7 @@ Page {
         Button {
             id:showButton
             text: qsTr("Show posts in")+" r/"+subreddit
-            anchors { horizontalCenter: parent.horizontalCenter; top: about.bottom; margins: 10}
+            anchors { horizontalCenter: parent.horizontalCenter; top: about.bottom; margins: Suru.units.gu(2)}
             onClicked: {
                 globalUtils.getMainPage().refresh(subreddit)
                 pageStack.pop(globalUtils.getMainPage(),StackView.ReplaceTransition)
@@ -107,7 +107,7 @@ Page {
 
             text: "<style>a {color: #e95420 }</style>\n" + aboutSubredditManager.longDescription
             textFormat: Text.RichText
-            anchors{ left: parent.left;top:showButton.bottom;right: parent.right;margins: 10}
+            anchors{ left: parent.left;top:showButton.bottom;right: parent.right;margins: Suru.units.gu(2)}
             wrapMode: "WordWrap"
             onLinkActivated: globalUtils.openLink(link)
         }

--- a/ubuntu-touch/Qml/Pages/SubredditsPage.qml
+++ b/ubuntu-touch/Qml/Pages/SubredditsPage.qml
@@ -39,7 +39,7 @@ Page {
             width: parent.width
             currentIndex: swipeView.currentIndex
             contentHeight: undefined
-            leftPadding: 10
+            leftPadding: Suru.units.gu(2)
             background: Rectangle {
                 color: Suru.color(Suru.Orange,1)
             }
@@ -61,7 +61,7 @@ Page {
                     else
                         parent = 0
                 }
-                padding: 6
+                padding: Suru.units.gu(1)
             }
 
             TabButton {
@@ -81,7 +81,7 @@ Page {
                     else
                         parent = 0
                 }
-                padding: 6
+                padding: Suru.units.gu(1)
             }
 
             TabButton {
@@ -91,7 +91,7 @@ Page {
                     font.weight: Font.Normal
                     color: Suru.color(Suru.White,1)
                 }
-                padding: 6
+                padding: Suru.units.gu(1)
                 width: implicitWidth
             }
             TabButton {
@@ -101,7 +101,7 @@ Page {
                     font.weight: Font.Normal
                     color: Suru.color(Suru.White,1)
                 }
-                padding: 6
+                padding: Suru.units.gu(1)
                 width: implicitWidth
             }
             TabButton {
@@ -111,7 +111,7 @@ Page {
                     font.weight: Font.Normal
                     color: Suru.color(Suru.White,1)
                 }
-                padding: 6
+                padding: Suru.units.gu(1)
                 width: implicitWidth
             }
             onCurrentIndexChanged: {

--- a/ubuntu-touch/Qml/Pages/UserPage.qml
+++ b/ubuntu-touch/Qml/Pages/UserPage.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import quickddit.Core 1.0
 import "../"
 import "../Delegates"
@@ -36,22 +37,22 @@ Page {
                 width: parent.width
                 CircleImage {
                     source: userManager.user.iconImg
-                    width: Math.min(150,parent.width/4)
+                    width: Math.min(Suru.units.gu(18),parent.width/4)
                     height: width
                 }
 
                 Label {
                     anchors.bottom: parent.bottom
-                    padding: 10
+                    padding: Suru.units.gu(2)
                     text: "/u/"+username
-                    font.pointSize: 18
+                    font.pixelSize: Suru.units.rem(1.5)
                 }
             }
             Row {
                 anchors.right: parent.right
                 Label {
                     anchors.verticalCenter: parent.verticalCenter
-                    padding: 5
+                    padding: Suru.units.gu(1)
                     text: userManager.user.linkKarma+" link / " +userManager.user.commentKarma+" comment karma"
                 }
                 Button {

--- a/ubuntu-touch/Qml/Pages/WebViewer.qml
+++ b/ubuntu-touch/Qml/Pages/WebViewer.qml
@@ -36,7 +36,7 @@ Page {
             ActionButton {
                 id:del
                 ico: "qrc:/Icons/reload.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 onClicked: {
                     webView.reload();
@@ -46,7 +46,7 @@ Page {
             ActionButton {
                 id:edit
                 ico: "qrc:/Icons/webbrowser-app-symbolic.svg"
-                size: 20
+                size: Suru.units.gu(3)
                 color: Suru.color(Suru.White,1)
                 onClicked: {
                     Qt.openUrlExternally(url);
@@ -59,6 +59,7 @@ Page {
         anchors.fill: parent
         id:webView
         settings.fullScreenSupportEnabled: true
+        zoomFactor: Suru.units.dp(1.0)
 
         onFullScreenRequested: {
             if(request.toggleOn) {

--- a/ubuntu-touch/Qml/PostButtonRow.qml
+++ b/ubuntu-touch/Qml/PostButtonRow.qml
@@ -88,8 +88,8 @@ Row{
             Image{
                 anchors.verticalCenter: parent.verticalCenter
                 source: "qrc:/Icons/message.svg"
-                width: 24
-                height: 24
+                width: Suru.units.gu(3)
+                height: Suru.units.gu(3)
                 layer.enabled: true
                 layer.effect: ColorOverlay {
                     color: Suru.foregroundColor

--- a/ubuntu-touch/Qml/RichTextEditor.qml
+++ b/ubuntu-touch/Qml/RichTextEditor.qml
@@ -9,7 +9,7 @@ Item {
 
     Row {
         id: formatRow
-        height: 36
+        height: Suru.units.gu(4.5)
 
         anchors { top: parent.top; left: parent.left }
         ActionButton {

--- a/ubuntu-touch/Qml/SubredditsDrawer.qml
+++ b/ubuntu-touch/Qml/SubredditsDrawer.qml
@@ -18,12 +18,13 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
 import quickddit.Core 1.0
 
 Drawer {
     id:subredditsDrawer
     height: window.height
-    width: 250
+    width: Suru.units.gu(31)
     dragMargin: 0
     function showSubreddit(subreddit) {
         var mainPage = globalUtils.getMainPage();

--- a/ubuntu-touch/main.qml
+++ b/ubuntu-touch/main.qml
@@ -83,7 +83,7 @@ ApplicationWindow {
 
             Label {
                 id:titleLabel
-                font.pointSize: 14
+                font.pixelSize: Suru.units.rem(1)
                 font.weight: Font.Normal
                 color: Suru.color(Suru.White,1)
                 elide: "ElideRight"
@@ -111,7 +111,7 @@ ApplicationWindow {
                     x: parent.width - width
                     y:parent.y+parent.height
                     transformOrigin: Menu.TopRight
-                    width: 200
+                    width: Suru.units.gu(25)
 
                     MenuItem {
                         txt: qsTr("My Subreddits")


### PR DESCRIPTION
This change will make the application respect the scaling in Lomiri. I usually tried to round towards the nearest grid unit (8px by default), so the sizes of elements may not exactly be as they were. 

This change is most noticeable when you change the element size in the Ubuntu Touch Tweak Tool, as I did for my PinePhone. 

Before this pull request:
![screenshot20210525_160628975](https://user-images.githubusercontent.com/4262067/119540868-35c46080-bd8e-11eb-9a2c-991b7af7c835.png)

After this pull request:
![image](https://user-images.githubusercontent.com/4262067/119540594-e1b97c00-bd8d-11eb-86d1-59c8d212fed2.png)
